### PR TITLE
Close stores/clients and delete local files after tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,15 +158,10 @@ func main() {
     if err != nil {
         panic(err)
     }
+    defer client.Close()
 
     // Store, retrieve, print and delete a value
     interactWithStore(client)
-
-    // Close client
-    err = client.Close()
-    if err != nil {
-        panic(err)
-    }
 }
 
 // interactWithStore stores, retrieves, prints and deletes a value.
@@ -204,6 +199,7 @@ func interactWithStore(store gokv.Store) {
 As described in the comments, that code does the following:
 
 1. Create a client for Redis
+   - Some implementations' stores/clients don't require to be closed, but when working with the interface (for example as function parameter) you *must* call `Close()` because you don't know which implementation is passed. Even if you work with a specific implementation you *should* always call `Close()`, so you can easily change the implementation without the risk of forgetting to add the call.
 2. Call `interactWithStore()`, which requires a `gokv.Store` as parameter. This method then:
     1. Stores an object of type `foo` in the Redis server running on `localhost:6379` with the key `foo123`
     2. Retrieves the value for the key `foo123`

--- a/bigcache/bigcache_test.go
+++ b/bigcache/bigcache_test.go
@@ -14,12 +14,14 @@ func TestStore(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		store := createStore(t, encoding.JSON)
+		defer store.Close()
 		test.TestStore(store, t)
 	})
 
 	// Test with gob
 	t.Run("gob", func(t *testing.T) {
 		store := createStore(t, encoding.Gob)
+		defer store.Close()
 		test.TestStore(store, t)
 	})
 }
@@ -29,12 +31,14 @@ func TestTypes(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		store := createStore(t, encoding.JSON)
+		defer store.Close()
 		test.TestTypes(store, t)
 	})
 
 	// Test with gob
 	t.Run("gob", func(t *testing.T) {
 		store := createStore(t, encoding.Gob)
+		defer store.Close()
 		test.TestTypes(store, t)
 	})
 }
@@ -42,6 +46,7 @@ func TestTypes(t *testing.T) {
 // TestStoreConcurrent launches a bunch of goroutines that concurrently work with one store.
 func TestStoreConcurrent(t *testing.T) {
 	store := createStore(t, encoding.JSON)
+	defer store.Close()
 
 	goroutineCount := 1000
 
@@ -52,6 +57,7 @@ func TestStoreConcurrent(t *testing.T) {
 func TestErrors(t *testing.T) {
 	// Test empty key
 	store := createStore(t, encoding.JSON)
+	defer store.Close()
 	err := store.Set("", "bar")
 	if err == nil {
 		t.Error("Expected an error")
@@ -72,6 +78,7 @@ func TestNil(t *testing.T) {
 
 	t.Run("set nil with JSON marshalling", func(t *testing.T) {
 		store := createStore(t, encoding.JSON)
+		defer store.Close()
 		err := store.Set("foo", nil)
 		if err == nil {
 			t.Error("Expected an error")
@@ -80,6 +87,7 @@ func TestNil(t *testing.T) {
 
 	t.Run("set nil with Gob marshalling", func(t *testing.T) {
 		store := createStore(t, encoding.Gob)
+		defer store.Close()
 		err := store.Set("foo", nil)
 		if err == nil {
 			t.Error("Expected an error")
@@ -91,6 +99,7 @@ func TestNil(t *testing.T) {
 	createTest := func(codec encoding.Codec) func(t *testing.T) {
 		return func(t *testing.T) {
 			store := createStore(t, codec)
+			defer store.Close()
 
 			// Prep
 			err := store.Set("foo", test.Foo{Bar: "baz"})
@@ -136,6 +145,7 @@ func TestEvictionOnMaxSize(t *testing.T) {
 		HardMaxCacheSize: 1,
 	}
 	store, err := bigcache.NewStore(options)
+	defer store.Close()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cockroachdb/cockroachdb_test.go
+++ b/cockroachdb/cockroachdb_test.go
@@ -22,12 +22,14 @@ func TestClient(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
+		defer client.Close()
 		test.TestStore(client, t)
 	})
 
 	// Test with gob
 	t.Run("gob", func(t *testing.T) {
 		client := createClient(t, encoding.Gob)
+		defer client.Close()
 		test.TestStore(client, t)
 	})
 }
@@ -43,12 +45,14 @@ func TestTypes(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
+		defer client.Close()
 		test.TestTypes(client, t)
 	})
 
 	// Test with gob
 	t.Run("gob", func(t *testing.T) {
 		client := createClient(t, encoding.Gob)
+		defer client.Close()
 		test.TestTypes(client, t)
 	})
 }
@@ -62,6 +66,7 @@ func TestClientConcurrent(t *testing.T) {
 	}
 
 	client := createClient(t, encoding.JSON)
+	defer client.Close()
 
 	goroutineCount := 1000
 
@@ -78,6 +83,7 @@ func TestErrors(t *testing.T) {
 
 	// Test empty key
 	client := createClient(t, encoding.JSON)
+	defer client.Close()
 	err := client.Set("", "bar")
 	if err == nil {
 		t.Error("Expected an error")
@@ -104,6 +110,7 @@ func TestNil(t *testing.T) {
 
 	t.Run("set nil with JSON marshalling", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
+		defer client.Close()
 		err := client.Set("foo", nil)
 		if err == nil {
 			t.Error("Expected an error")
@@ -112,6 +119,7 @@ func TestNil(t *testing.T) {
 
 	t.Run("set nil with Gob marshalling", func(t *testing.T) {
 		client := createClient(t, encoding.Gob)
+		defer client.Close()
 		err := client.Set("foo", nil)
 		if err == nil {
 			t.Error("Expected an error")
@@ -123,6 +131,7 @@ func TestNil(t *testing.T) {
 	createTest := func(codec encoding.Codec) func(t *testing.T) {
 		return func(t *testing.T) {
 			client := createClient(t, codec)
+			defer client.Close()
 
 			// Prep
 			err := client.Set("foo", test.Foo{Bar: "baz"})
@@ -174,6 +183,7 @@ func checkConnection() bool {
 		log.Printf("An error occurred during testing the connection to the server: %v\n", err)
 		return false
 	}
+	defer db.Close()
 
 	err = db.Ping()
 	if err != nil {

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -26,12 +26,14 @@ func TestClient(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
+		defer client.Close()
 		test.TestStore(client, t)
 	})
 
 	// Test with gob
 	t.Run("gob", func(t *testing.T) {
 		client := createClient(t, encoding.Gob)
+		defer client.Close()
 		test.TestStore(client, t)
 	})
 }
@@ -47,12 +49,14 @@ func TestTypes(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
+		defer client.Close()
 		test.TestTypes(client, t)
 	})
 
 	// Test with gob
 	t.Run("gob", func(t *testing.T) {
 		client := createClient(t, encoding.Gob)
+		defer client.Close()
 		test.TestTypes(client, t)
 	})
 }
@@ -66,6 +70,7 @@ func TestClientConcurrent(t *testing.T) {
 	}
 
 	client := createClient(t, encoding.JSON)
+	defer client.Close()
 
 	// TODO: Should test 1000, but that only works with GCP
 	// or a locally running emulator with enough resources.
@@ -85,6 +90,7 @@ func TestErrors(t *testing.T) {
 
 	// Test empty key
 	client := createClient(t, encoding.JSON)
+	defer client.Close()
 	err := client.Set("", "bar")
 	if err == nil {
 		t.Error("Expected an error")
@@ -111,6 +117,7 @@ func TestNil(t *testing.T) {
 
 	t.Run("set nil with JSON marshalling", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
+		defer client.Close()
 		err := client.Set("foo", nil)
 		if err == nil {
 			t.Error("Expected an error")
@@ -119,6 +126,7 @@ func TestNil(t *testing.T) {
 
 	t.Run("set nil with Gob marshalling", func(t *testing.T) {
 		client := createClient(t, encoding.Gob)
+		defer client.Close()
 		err := client.Set("foo", nil)
 		if err == nil {
 			t.Error("Expected an error")
@@ -130,6 +138,7 @@ func TestNil(t *testing.T) {
 	createTest := func(codec encoding.Codec) func(t *testing.T) {
 		return func(t *testing.T) {
 			client := createClient(t, codec)
+			defer client.Close()
 
 			// Prep
 			err := client.Set("foo", test.Foo{Bar: "baz"})
@@ -186,6 +195,7 @@ func checkConnection() bool {
 		fmt.Printf("Client couldn't be created: %v\n", err)
 		return false
 	}
+	defer dsClient.Close()
 
 	// Let's use AllocateIDs() as connection test.
 	// It takes incomplete keys and returns valid keys.

--- a/docs.go
+++ b/docs.go
@@ -27,15 +27,10 @@ Example code for using Redis:
 		if err != nil {
 			panic(err)
 		}
+		defer client.Close()
 
 		// Store, retrieve, print and delete a value
 		interactWithStore(client)
-
-		// Close client
-		err = client.Close()
-		if err != nil {
-			panic(err)
-		}
 	}
 
 	// interactWithStore stores, retrieves, prints and deletes a value.

--- a/etcd/etcd_test.go
+++ b/etcd/etcd_test.go
@@ -25,12 +25,14 @@ func TestClient(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
+		defer client.Close()
 		test.TestStore(client, t)
 	})
 
 	// Test with gob
 	t.Run("gob", func(t *testing.T) {
 		client := createClient(t, encoding.Gob)
+		defer client.Close()
 		test.TestStore(client, t)
 	})
 }
@@ -46,12 +48,14 @@ func TestTypes(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
+		defer client.Close()
 		test.TestTypes(client, t)
 	})
 
 	// Test with gob
 	t.Run("gob", func(t *testing.T) {
 		client := createClient(t, encoding.Gob)
+		defer client.Close()
 		test.TestTypes(client, t)
 	})
 }
@@ -65,6 +69,7 @@ func TestClientConcurrent(t *testing.T) {
 	}
 
 	client := createClient(t, encoding.JSON)
+	defer client.Close()
 
 	goroutineCount := 1000
 
@@ -81,6 +86,7 @@ func TestErrors(t *testing.T) {
 
 	// Test empty key
 	client := createClient(t, encoding.JSON)
+	defer client.Close()
 	err := client.Set("", "bar")
 	if err == nil {
 		t.Error("Expected an error")
@@ -107,6 +113,7 @@ func TestNil(t *testing.T) {
 
 	t.Run("set nil with JSON marshalling", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
+		defer client.Close()
 		err := client.Set("foo", nil)
 		if err == nil {
 			t.Error("Expected an error")
@@ -115,6 +122,7 @@ func TestNil(t *testing.T) {
 
 	t.Run("set nil with Gob marshalling", func(t *testing.T) {
 		client := createClient(t, encoding.Gob)
+		defer client.Close()
 		err := client.Set("foo", nil)
 		if err == nil {
 			t.Error("Expected an error")
@@ -126,6 +134,7 @@ func TestNil(t *testing.T) {
 	createTest := func(codec encoding.Codec) func(t *testing.T) {
 		return func(t *testing.T) {
 			client := createClient(t, codec)
+			defer client.Close()
 
 			// Prep
 			err := client.Set("foo", test.Foo{Bar: "baz"})
@@ -185,6 +194,7 @@ func TestDefaultTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer client.Close()
 
 	err = client.Set("foo", "bar")
 	if err != nil {
@@ -219,6 +229,7 @@ func checkConnection() bool {
 		log.Printf("An error occurred during testing the connection to the server: %v\n", err)
 		return false
 	}
+	defer cli.Close()
 
 	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()

--- a/examples/main.go
+++ b/examples/main.go
@@ -19,15 +19,10 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	defer client.Close()
 
 	// Store, retrieve, print and delete a value
 	interactWithStore(client)
-
-	// Close client
-	err = client.Close()
-	if err != nil {
-		panic(err)
-	}
 }
 
 // interactWithStore stores, retrieves, prints and deletes a value.

--- a/mongodb/mongodb_test.go
+++ b/mongodb/mongodb_test.go
@@ -23,12 +23,14 @@ func TestClient(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
+		defer client.Close()
 		test.TestStore(client, t)
 	})
 
 	// Test with gob
 	t.Run("gob", func(t *testing.T) {
 		client := createClient(t, encoding.Gob)
+		defer client.Close()
 		test.TestStore(client, t)
 	})
 }
@@ -44,12 +46,14 @@ func TestTypes(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
+		defer client.Close()
 		test.TestTypes(client, t)
 	})
 
 	// Test with gob
 	t.Run("gob", func(t *testing.T) {
 		client := createClient(t, encoding.Gob)
+		defer client.Close()
 		test.TestTypes(client, t)
 	})
 }
@@ -63,6 +67,7 @@ func TestClientConcurrent(t *testing.T) {
 	}
 
 	client := createClient(t, encoding.JSON)
+	defer client.Close()
 
 	goroutineCount := 1000
 
@@ -79,6 +84,7 @@ func TestErrors(t *testing.T) {
 
 	// Test empty key
 	client := createClient(t, encoding.JSON)
+	defer client.Close()
 	err := client.Set("", "bar")
 	if err == nil {
 		t.Error("Expected an error")
@@ -114,6 +120,7 @@ func TestNil(t *testing.T) {
 
 	t.Run("set nil with JSON marshalling", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
+		defer client.Close()
 		err := client.Set("foo", nil)
 		if err == nil {
 			t.Error("Expected an error")
@@ -122,6 +129,7 @@ func TestNil(t *testing.T) {
 
 	t.Run("set nil with Gob marshalling", func(t *testing.T) {
 		client := createClient(t, encoding.Gob)
+		defer client.Close()
 		err := client.Set("foo", nil)
 		if err == nil {
 			t.Error("Expected an error")
@@ -133,6 +141,7 @@ func TestNil(t *testing.T) {
 	createTest := func(codec encoding.Codec) func(t *testing.T) {
 		return func(t *testing.T) {
 			client := createClient(t, codec)
+			defer client.Close()
 
 			// Prep
 			err := client.Set("foo", test.Foo{Bar: "baz"})
@@ -184,6 +193,7 @@ func checkConnection() bool {
 		log.Printf("An error occurred during testing the connection to the server: %v\n", err)
 		return false
 	}
+	defer session.Close()
 	if err = session.Ping(); err != nil {
 		log.Printf("An error occurred during testing the connection to the server: %v\n", err)
 		return false

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -24,12 +24,14 @@ func TestClient(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
+		defer client.Close()
 		test.TestStore(client, t)
 	})
 
 	// Test with gob
 	t.Run("gob", func(t *testing.T) {
 		client := createClient(t, encoding.Gob)
+		defer client.Close()
 		test.TestStore(client, t)
 	})
 }
@@ -45,12 +47,14 @@ func TestTypes(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
+		defer client.Close()
 		test.TestTypes(client, t)
 	})
 
 	// Test with gob
 	t.Run("gob", func(t *testing.T) {
 		client := createClient(t, encoding.Gob)
+		defer client.Close()
 		test.TestTypes(client, t)
 	})
 }
@@ -64,6 +68,7 @@ func TestClientConcurrent(t *testing.T) {
 	}
 
 	client := createClient(t, encoding.JSON)
+	defer client.Close()
 
 	goroutineCount := 1000
 
@@ -80,6 +85,7 @@ func TestErrors(t *testing.T) {
 
 	// Test empty key
 	client := createClient(t, encoding.JSON)
+	defer client.Close()
 	err := client.Set("", "bar")
 	if err == nil {
 		t.Error("Expected an error")
@@ -106,6 +112,7 @@ func TestNil(t *testing.T) {
 
 	t.Run("set nil with JSON marshalling", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
+		defer client.Close()
 		err := client.Set("foo", nil)
 		if err == nil {
 			t.Error("Expected an error")
@@ -114,6 +121,7 @@ func TestNil(t *testing.T) {
 
 	t.Run("set nil with Gob marshalling", func(t *testing.T) {
 		client := createClient(t, encoding.Gob)
+		defer client.Close()
 		err := client.Set("foo", nil)
 		if err == nil {
 			t.Error("Expected an error")
@@ -125,6 +133,7 @@ func TestNil(t *testing.T) {
 	createTest := func(codec encoding.Codec) func(t *testing.T) {
 		return func(t *testing.T) {
 			client := createClient(t, codec)
+			defer client.Close()
 
 			// Prep
 			err := client.Set("foo", test.Foo{Bar: "baz"})
@@ -171,6 +180,7 @@ func TestDBcreation(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	defer client.Close()
 	err = client.Set("foo", "bar")
 	if err != nil {
 		t.Error(err)
@@ -213,6 +223,7 @@ func TestDefaultMaxOpenConnections(t *testing.T) {
 
 	options := mysql.Options{}
 	client, err := mysql.NewClient(options)
+	defer client.Close()
 	if err != nil {
 		t.Error(err)
 	}
@@ -241,6 +252,7 @@ func checkConnection() bool {
 		log.Printf("An error occurred during testing the connection to the server: %v\n", err)
 		return false
 	}
+	defer db.Close()
 
 	err = db.Ping()
 	if err != nil {

--- a/postgresql/postgresql_test.go
+++ b/postgresql/postgresql_test.go
@@ -121,6 +121,7 @@ func TestNil(t *testing.T) {
 
 	t.Run("set nil with JSON marshalling", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
+		defer client.Close()
 		err := client.Set("foo", nil)
 		if err == nil {
 			t.Error("Expected an error")
@@ -129,6 +130,7 @@ func TestNil(t *testing.T) {
 
 	t.Run("set nil with Gob marshalling", func(t *testing.T) {
 		client := createClient(t, encoding.Gob)
+		defer client.Close()
 		err := client.Set("foo", nil)
 		if err == nil {
 			t.Error("Expected an error")
@@ -140,6 +142,7 @@ func TestNil(t *testing.T) {
 	createTest := func(codec encoding.Codec) func(t *testing.T) {
 		return func(t *testing.T) {
 			client := createClient(t, codec)
+			defer client.Close()
 
 			// Prep
 			err := client.Set("foo", test.Foo{Bar: "baz"})
@@ -178,6 +181,7 @@ func TestClose(t *testing.T) {
 	}
 
 	client := createClient(t, encoding.JSON)
+	defer client.Close()
 	err := client.Close()
 	if err != nil {
 		t.Error(err)
@@ -192,6 +196,7 @@ func checkConnection() bool {
 		log.Printf("An error occurred during testing the connection to the server: %v\n", err)
 		return false
 	}
+	defer db.Close()
 
 	err = db.Ping()
 	if err != nil {


### PR DESCRIPTION
Closes #40.

The test doesn't delete anything when the test server runs in Docker, because the containers are ephemeral (`--rm`) anyway (at least they're started that way on Travis CI and they *should* be started that way locally as well).

One future improvement could be to also delete all key-value pairs / buckets / tables from the cloud services, because only testing with the emulators isn't enough, so every now and then the real cloud services are tested with the existing test code. When the key-value pairs aren't deleted in that case, this can lead to storage costs.