### PR TITLE
Add expiration support

### DIFF
--- a/badgerdb/badgerdb_test.go
+++ b/badgerdb/badgerdb_test.go
@@ -169,6 +169,12 @@ func TestNonExistingDir(t *testing.T) {
 	}
 }
 
+func TestExp(t *testing.T) {
+	store, _ := createStore(t, encoding.JSON)
+	defer store.Close()
+	test.TestExpiration(store, t)
+}
+
 func createStore(t *testing.T, codec encoding.Codec) (badgerdb.Store, string) {
 	randPath := generateRandomTempDBpath(t)
 	options := badgerdb.Options{

--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,6 @@
+package gokv
+
+type Cache struct {
+	Store
+	SetterWithExp
+}

--- a/cache.go
+++ b/cache.go
@@ -1,6 +1,6 @@
 package gokv
 
-type Cache struct {
+type Cache interface {
 	Store
 	SetterWithExp
 }

--- a/etcd/etcd_test.go
+++ b/etcd/etcd_test.go
@@ -255,3 +255,13 @@ func createClient(t *testing.T, codec encoding.Codec) etcd.Client {
 	}
 	return client
 }
+
+func TestExp(t *testing.T) {
+	if !checkConnection() {
+		t.Skip("No connection to etcd could be established. Probably not running in a proper test environment.")
+	}
+
+	client := createClient(t, encoding.JSON)
+	defer client.Close()
+	test.TestExpiration(client, t)
+}

--- a/exp.go
+++ b/exp.go
@@ -1,0 +1,9 @@
+package gokv
+
+import "time"
+
+// SetterWithExp is an abstraction for setter with expiration feature
+type SetterWithExp interface {
+	// SetExp works like Set, but supports key expiration
+	SetExp(k string, v interface{}, exp time.Duration) error
+}

--- a/freecache/freecache.go
+++ b/freecache/freecache.go
@@ -2,6 +2,7 @@ package freecache
 
 import (
 	"github.com/coocood/freecache"
+	"time"
 
 	"github.com/philippgille/gokv/encoding"
 	"github.com/philippgille/gokv/util"
@@ -13,6 +14,23 @@ const minSize = 512 * 1024
 type Store struct {
 	s     *freecache.Cache
 	codec encoding.Codec
+}
+
+// SetExp works like Set, but supports key expiration
+func (s Store) SetExp(k string, v interface{}, exp time.Duration) error {
+	if !util.CheckExp(exp) {
+		return nil
+	}
+	if err := util.CheckKeyAndValue(k, v); err != nil {
+		return err
+	}
+
+	data, err := s.codec.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	return s.s.Set([]byte(k), data, int(exp.Seconds()))
 }
 
 // Set stores the given value for the given key.

--- a/freecache/freecache_test.go
+++ b/freecache/freecache_test.go
@@ -65,6 +65,12 @@ func TestErrors(t *testing.T) {
 	}
 }
 
+func TestExp(t *testing.T) {
+	store := createStore(t, encoding.JSON)
+	defer store.Close()
+	test.TestExpiration(store, t)
+}
+
 // TestNil tests the behaviour when passing nil or pointers to nil values to some methods.
 func TestNil(t *testing.T) {
 	// Test setting nil

--- a/hazelcast/hazelcast.go
+++ b/hazelcast/hazelcast.go
@@ -2,6 +2,7 @@ package hazelcast
 
 import (
 	"fmt"
+	"time"
 
 	hazelcast "github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/config/property"
@@ -24,6 +25,28 @@ type Client struct {
 	// does the map still work or do we need to get the map from the client again?
 	m     core.Map
 	codec encoding.Codec
+}
+
+// SetExp works like Set, but supports key expiration
+func (c Client) SetExp(k string, v interface{}, exp time.Duration) error {
+	if !util.CheckExp(exp) {
+		return nil
+	}
+	if err := util.CheckKeyAndValue(k, v); err != nil {
+		return err
+	}
+
+	data, err := c.codec.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	err = c.m.SetWithTTL(k, data, exp)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Set stores the given value for the given key.

--- a/hazelcast/hazelcast_test.go
+++ b/hazelcast/hazelcast_test.go
@@ -95,6 +95,16 @@ func TestErrors(t *testing.T) {
 	}
 }
 
+func TestExp(t *testing.T) {
+	if !checkConnection() {
+		t.Skip("No connection to Hazelcast could be established. Probably not running in a proper test environment.")
+	}
+
+	client := createClient(t, encoding.JSON)
+	defer client.Close()
+	test.TestExpiration(client, t)
+}
+
 // TestNil tests the behaviour when passing nil or pointers to nil values to some methods.
 //
 // Note: This test is only executed if the initial connection to Hazelcast works.

--- a/memcached/memcached_test.go
+++ b/memcached/memcached_test.go
@@ -101,7 +101,7 @@ func TestErrors(t *testing.T) {
 // Note: This test is only executed if the initial connection to Redis works.
 func TestExp(t *testing.T) {
 	if !checkConnection() {
-		t.Skip("No connection to Redis could be established. Probably not running in a proper test environment.")
+		t.Skip("No connection to Memcached could be established. Probably not running in a proper test environment.")
 	}
 
 	client := createClient(t, encoding.JSON)

--- a/memcached/memcached_test.go
+++ b/memcached/memcached_test.go
@@ -96,6 +96,19 @@ func TestErrors(t *testing.T) {
 	}
 }
 
+// TestExp tests expiration support.
+//
+// Note: This test is only executed if the initial connection to Redis works.
+func TestExp(t *testing.T) {
+	if !checkConnection() {
+		t.Skip("No connection to Redis could be established. Probably not running in a proper test environment.")
+	}
+
+	client := createClient(t, encoding.JSON)
+	defer client.Close()
+	test.TestExpiration(client, t)
+}
+
 // TestNil tests the behaviour when passing nil or pointers to nil values to some methods.
 //
 // Note: This test is only executed if the initial connection to Memcached works.

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"github.com/go-redis/redis"
+	"time"
 
 	"github.com/philippgille/gokv/encoding"
 	"github.com/philippgille/gokv/util"
@@ -11,6 +12,27 @@ import (
 type Client struct {
 	c     *redis.Client
 	codec encoding.Codec
+}
+
+// SetExp works like Set, but supports key expiration
+func (c Client) SetExp(k string, v interface{}, exp time.Duration) error {
+	if !util.CheckExp(exp) {
+		return nil
+	}
+	if err := util.CheckKeyAndValue(k, v); err != nil {
+		return err
+	}
+
+	data, err := c.codec.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	err = c.c.Set(k, string(data), exp).Err()
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // Set stores the given value for the given key.

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -1,10 +1,9 @@
 package redis_test
 
 import (
+	goredis "github.com/go-redis/redis"
 	"log"
 	"testing"
-
-	goredis "github.com/go-redis/redis"
 
 	"github.com/philippgille/gokv/encoding"
 	"github.com/philippgille/gokv/redis"
@@ -101,6 +100,19 @@ func TestErrors(t *testing.T) {
 	if err == nil {
 		t.Error("Expected an error")
 	}
+}
+
+// TestExp tests expiration support.
+//
+// Note: This test is only executed if the initial connection to Redis works.
+func TestExp(t *testing.T) {
+	if !checkConnection(testDbNumber) {
+		t.Skip("No connection to Redis could be established. Probably not running in a proper test environment.")
+	}
+
+	client := createClient(t, encoding.JSON)
+	defer client.Close()
+	test.TestExpiration(client, t)
 }
 
 // TestNil tests the behaviour when passing nil or pointers to nil values to some methods.

--- a/test/test.go
+++ b/test/test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-test/deep"
 
@@ -352,5 +353,23 @@ func InteractWithStore(store gokv.Store, key string, t *testing.T, waitGroup *sy
 	_, err = store.Get(key, new(Foo))
 	if err != nil {
 		t.Error(err)
+	}
+}
+
+func TestExpiration(cache gokv.Cache, t *testing.T) {
+	err := cache.SetExp("key", "value", 5*time.Second)
+	if err != nil {
+		t.Error(err)
+	}
+
+	time.Sleep(5 * time.Second)
+
+	r := "value"
+	ok, err := cache.Get("key", &r)
+	if err != nil {
+		t.Error(err)
+	}
+	if ok {
+		t.Error("pair should be removed")
 	}
 }

--- a/util/util.go
+++ b/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"errors"
+	"time"
 )
 
 // CheckKeyAndValue returns an error if k == "" or if v == nil
@@ -26,4 +27,14 @@ func CheckVal(v interface{}) error {
 		return errors.New("The passed value is nil, which is not allowed")
 	}
 	return nil
+}
+
+const MinExpiration = 10 * time.Second
+
+// CheckExp returns false if expiration time is too small
+func CheckExp(exp time.Duration) bool {
+	if exp < MinExpiration {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
#86

Defines two new interfaces:
```go
type SetterWithExp interface {
	SetExp(k string, v interface{}, exp time.Duration) error
}
```
and
```go
type Cache interface {
	Store
	SetterWithExp
}
```

implemented for

- Redis
- Memcached
- Freecache
- Hazelcast
- BadgerDB
- etcd

