### PR TITLE
s3: Add option to bypass CreateBucket

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -149,6 +149,9 @@ type Options struct {
 	// and some work only with the path style (especially self-hosted services like a Minio server running on localhost).
 	// Optional (false by default).
 	UsePathStyleAddressing bool
+	// Call createBucket
+	// Optional (false by default)
+	BypassCreateBucket bool
 	// Encoding format.
 	// Optional (encoding.JSON by default).
 	Codec encoding.Codec
@@ -221,13 +224,15 @@ func NewClient(options Options) (Client, error) {
 	svc := awss3.New(session)
 
 	// Create the bucket if it doesn't exist yet.
-	createBucketInput := awss3.CreateBucketInput{
-		Bucket: aws.String(options.BucketName),
-	}
-	origS3 := options.CustomEndpoint == ""
-	err = createBucket(origS3, svc, createBucketInput, options.BucketName)
-	if err != nil {
-		return result, err
+	if !options.BypassCreateBucket {
+		createBucketInput := awss3.CreateBucketInput{
+			Bucket: aws.String(options.BucketName),
+		}
+		origS3 := options.CustomEndpoint == ""
+		err = createBucket(origS3, svc, createBucketInput, options.BucketName)
+		if err != nil {
+			return result, err
+		}
 	}
 
 	result.c = svc


### PR DESCRIPTION
Multiple simultaneous calls (use case was multiple gokv-backed CLI utilities in a pipeline) to NewClient causes an error:
```
A conflicting conditional operation is currently in progress against this resource.
```
This occurs for S3 CreateBucket. Relying on the error to be awss3.ErrCodeBucketAlreadyOwnedByYou is fine, but the operation will still block other callers. This patch provides a mechanism to bypass bucket creation.