### PR TITLE
Adding encoding support for Protocol Buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ This repository contains the subpackage `encoding`, which is an abstraction and 
 
 - [X] JSON
 - [X] [gob](https://blog.golang.org/gobs-of-data)
+- [X] [proto](https://pkg.go.dev/github.com/golang/protobuf/proto)
 
 More formats will be supported in the future (e.g. XML).
 
@@ -128,6 +129,7 @@ Differences between the formats:
 - Depending on the use case, the custom (un-)marshal methods of one of the formats might be easier to implement
     - JSON: [`MarshalJSON() ([]byte, error)`](https://pkg.go.dev/encoding/json#Marshaler) and [`UnmarshalJSON([]byte) error`](https://pkg.go.dev/encoding/json#Unmarshaler)
     - gob: [`GobEncode() ([]byte, error)`](https://pkg.go.dev/encoding/gob#GobEncoder) and [`GobDecode([]byte) error`](https://pkg.go.dev/encoding/gob#GobDecoder)
+    - proto: [`Marshal(proto.Message) ([]byte, error)`](https://pkg.go.dev/github.com/golang/protobuf/proto#Marshal) and [`Unmarshal([]byte, proto.Message) error`](https://pkg.go.dev/github.com/golang/protobuf/proto#Unmarshal)
 
 ### Roadmap
 

--- a/encoding/codec.go
+++ b/encoding/codec.go
@@ -14,4 +14,6 @@ var (
 	JSON = JSONcodec{}
 	// Gob is a GobCodec that encodes/decodes Go values to/from gob.
 	Gob = GobCodec{}
+	// PB is a PBcodec that encodes/decodes Go values to/from Protocol Buffers.
+	PB = PBcodec{}
 )

--- a/encoding/go.mod
+++ b/encoding/go.mod
@@ -1,3 +1,5 @@
 module github.com/philippgille/gokv/encoding
 
 go 1.18
+
+require google.golang.org/protobuf v1.31.0

--- a/encoding/go.sum
+++ b/encoding/go.sum
@@ -1,0 +1,8 @@
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
+google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=

--- a/encoding/proto.go
+++ b/encoding/proto.go
@@ -1,0 +1,30 @@
+package encoding
+
+import (
+	"errors"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// PBcodec encodes/decodes Go values to/from protocol buffers.
+type PBcodec struct{}
+
+// Marshal encodes a proto message struct into the binary wire format.
+// Passed value can't be any Go value, but must be an object of a proto message struct.
+func (c PBcodec) Marshal(v interface{}) ([]byte, error) {
+	msg, ok := v.(proto.Message)
+	if !ok {
+		return nil, errors.New("error casting interface to proto")
+	}
+	return proto.Marshal(msg)
+}
+
+// Unmarshal parses a wire-format message in proto message struct.
+// Passed value can't be any Go value, but must be an object of a proto message struct.
+func (c PBcodec) Unmarshal(data []byte, v interface{}) error {
+	msg, ok := v.(proto.Message)
+	if !ok {
+		return errors.New("error casting interface to proto")
+	}
+	return proto.Unmarshal(data, msg)
+}


### PR DESCRIPTION
According to proto documentation,
protojson produces a different output than the standard "encoding/json" package, 
which does not operate correctly on protocol buffer messages.

Fixes #128 