### PR TITLE
Fix CI double builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: test
-# Push is enough even for PRs from maintainers, but not from contributors
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Double builds were triggered when a maintainer pushed a new commit to an open PR, as it matched the push and the pull_request trigger. This didn't happen when contributors pushed to PRs, as that only triggered the pull_request one.