### PR TITLE
Use tparse for test output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,14 @@ jobs:
         with:
           version: v1.15.0
           install-only: true
+      - run: go install -v github.com/mfridman/tparse@v0.13.2
 
       - run: |
+          docker version
           go version
           go env
           mage -version
-          docker version
+          tparse -version
 
       # First build to check for compile errors
       - run: mage build

--- a/magefiles/test.go
+++ b/magefiles/test.go
@@ -26,7 +26,7 @@ func testImpl(impl string) (err error) {
 		defer os.Chdir("..") // This swallows the error in case there is one, but that's okay as the mage process is exited anyway
 
 		var out string
-		out, err = script.Exec("go test -v -race -coverprofile=coverage.txt -covermode=atomic").String()
+		out, err = script.Exec("go test -v -race -coverprofile=coverage.txt -covermode=atomic -json").Exec("tparse -all -progress").String()
 		fmt.Println(out)
 		return err
 	}
@@ -145,7 +145,7 @@ func testImpl(impl string) (err error) {
 	defer os.Chdir("..") // This swallows the error in case there is one, but that's okay as the mage process is exited anyway
 
 	var out string
-	out, err = script.Exec("go test -v -race -coverprofile=coverage.txt -covermode=atomic").String()
+	out, err = script.Exec("go test -v -race -coverprofile=coverage.txt -covermode=atomic -json").Exec("tparse -all -progress").String()
 	fmt.Println(out)
 
 	// If err is nil, the above deferred functions might set it


### PR DESCRIPTION
Maybe we should provide a tool installer in the magefile? Like `mage setup` or `mage install` and it installs all required CLI tools in the versions we use?

Or maybe better to change the magefile to check if tparse is installed, and only use it when it is?