### PR TITLE
Update and improve usage of GitHub Actions dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,9 @@ jobs:
         os: [windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          show-progress: 'false'
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: 'false'
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
+          cache-dependency-path: "**/go.sum"
       - uses: magefile/mage-action@v3
         with:
           version: v1.15.0


### PR DESCRIPTION
Update `actions/checkout` from v3 to v4, and `actions/setup-go` from v3 to v4.

Makes use of suppressing progress during Git checkout, and configures Go dependency caching.