### PR TITLE
Update BigCache from v2 to v3

### DIFF
--- a/bigcache/bigcache.go
+++ b/bigcache/bigcache.go
@@ -1,9 +1,10 @@
 package bigcache
 
 import (
+	"context"
 	"time"
 
-	"github.com/allegro/bigcache/v2"
+	"github.com/allegro/bigcache/v3"
 
 	"github.com/philippgille/gokv/encoding"
 	"github.com/philippgille/gokv/util"
@@ -115,7 +116,7 @@ func NewStore(options Options) (Store, error) {
 
 	config := bigcache.DefaultConfig(options.Eviction)
 	config.HardMaxCacheSize = options.HardMaxCacheSize
-	cache, err := bigcache.NewBigCache(config)
+	cache, err := bigcache.New(context.Background(), config)
 	if err != nil {
 		return result, err
 	}

--- a/bigcache/go.mod
+++ b/bigcache/go.mod
@@ -3,7 +3,7 @@ module github.com/philippgille/gokv/bigcache
 go 1.20
 
 require (
-	github.com/allegro/bigcache/v2 v2.2.5
+	github.com/allegro/bigcache/v3 v3.1.0
 	github.com/philippgille/gokv/encoding v0.6.0
 	github.com/philippgille/gokv/test v0.6.0
 	github.com/philippgille/gokv/util v0.6.0

--- a/bigcache/go.sum
+++ b/bigcache/go.sum
@@ -1,5 +1,5 @@
-github.com/allegro/bigcache/v2 v2.2.5 h1:mRc8r6GQjuJsmSKQNPsR5jQVXc8IJ1xsW5YXUYMLfqI=
-github.com/allegro/bigcache/v2 v2.2.5/go.mod h1:FppZsIO+IZk7gCuj5FiIDHGygD9xvWQcqg1uIPMb6tY=
+github.com/allegro/bigcache/v3 v3.1.0 h1:H2Vp8VOvxcrB91o86fUSVJFqeuz8kpyyB02eH3bSzwk=
+github.com/allegro/bigcache/v3 v3.1.0/go.mod h1:aPyh7jEvrog9zAwx5N7+JUQX5dZTSGpxF1LAR4dr35I=
 github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/philippgille/gokv v0.5.1-0.20191011213304-eb77f15b9c61 h1:GIHjzzfFa5MP+gaNJfa1Y9/L1qjh2NCKWcGIbJVizDs=


### PR DESCRIPTION
Version 2 is not maintained anymore, and there are not many changes to v3, so we can update without breaking anything on our side: https://github.com/allegro/bigcache/compare/v2.2.5...v3.1.0

In fact, this update fixes a concurrency issue that was probably coming from BigCache side. Running `go test -v -race -count 100 -run TestStoreConcurrent .` previously lead to one of the runs to have issues, but that seems to be solved.
We actually run into this in CI fairly often (e.g. latest one [here](https://github.com/philippgille/gokv/actions/runs/7079763394/job/19266756535)), so it's really useful to have this fixed.