### PR TITLE
Remove test skipping on connection error

### DIFF
--- a/cockroachdb/cockroachdb_test.go
+++ b/cockroachdb/cockroachdb_test.go
@@ -15,10 +15,6 @@ import (
 //
 // Note: This test is only executed if the initial connection to CockroachDB works.
 func TestClient(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to CockroachDB could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -38,10 +34,6 @@ func TestClient(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to CockroachDB works.
 func TestTypes(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to CockroachDB could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -61,10 +53,6 @@ func TestTypes(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to CockroachDB works.
 func TestClientConcurrent(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to CockroachDB could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 	defer client.Close()
 
@@ -77,10 +65,6 @@ func TestClientConcurrent(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to CockroachDB works.
 func TestErrors(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to CockroachDB could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test empty key
 	client := createClient(t, encoding.JSON)
 	defer client.Close()
@@ -102,10 +86,6 @@ func TestErrors(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to CockroachDB works.
 func TestNil(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to CockroachDB could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test setting nil
 
 	t.Run("set nil with JSON marshalling", func(t *testing.T) {
@@ -165,10 +145,6 @@ func TestNil(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to CockroachDB works.
 func TestClose(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to CockroachDB could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 	err := client.Close()
 	if err != nil {

--- a/cockroachdb/cockroachdb_test.go
+++ b/cockroachdb/cockroachdb_test.go
@@ -12,8 +12,6 @@ import (
 
 // TestClient tests if reading from, writing to and deleting from the store works properly.
 // A struct is used as value. See TestTypes() for a test that is simpler but tests all types.
-//
-// Note: This test is only executed if the initial connection to CockroachDB works.
 func TestClient(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -31,8 +29,6 @@ func TestClient(t *testing.T) {
 }
 
 // TestTypes tests if setting and getting values works with all Go types.
-//
-// Note: This test is only executed if the initial connection to CockroachDB works.
 func TestTypes(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -50,8 +46,6 @@ func TestTypes(t *testing.T) {
 }
 
 // TestClientConcurrent launches a bunch of goroutines that concurrently work with the CockroachDB client.
-//
-// Note: This test is only executed if the initial connection to CockroachDB works.
 func TestClientConcurrent(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 	defer client.Close()
@@ -62,8 +56,6 @@ func TestClientConcurrent(t *testing.T) {
 }
 
 // TestErrors tests some error cases.
-//
-// Note: This test is only executed if the initial connection to CockroachDB works.
 func TestErrors(t *testing.T) {
 	// Test empty key
 	client := createClient(t, encoding.JSON)
@@ -83,8 +75,6 @@ func TestErrors(t *testing.T) {
 }
 
 // TestNil tests the behaviour when passing nil or pointers to nil values to some methods.
-//
-// Note: This test is only executed if the initial connection to CockroachDB works.
 func TestNil(t *testing.T) {
 	// Test setting nil
 
@@ -142,8 +132,6 @@ func TestNil(t *testing.T) {
 }
 
 // TestClose tests if the close method returns any errors.
-//
-// Note: This test is only executed if the initial connection to CockroachDB works.
 func TestClose(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 	err := client.Close()

--- a/consul/consul_test.go
+++ b/consul/consul_test.go
@@ -18,10 +18,6 @@ import (
 //
 // Note: This test is only executed if the initial connection to Consul works.
 func TestClient(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Consul could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -39,10 +35,6 @@ func TestClient(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Consul works.
 func TestTypes(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Consul could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -60,10 +52,6 @@ func TestTypes(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Consul works.
 func TestClientConcurrent(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Consul could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 
 	// With 1000 we get rate limiting errors from the Consul container,
@@ -77,10 +65,6 @@ func TestClientConcurrent(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Consul works.
 func TestErrors(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Consul could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test empty key
 	client := createClient(t, encoding.JSON)
 	err := client.Set("", "bar")
@@ -101,10 +85,6 @@ func TestErrors(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Consul works.
 func TestNil(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Consul could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test setting nil
 
 	t.Run("set nil with JSON marshalling", func(t *testing.T) {
@@ -161,10 +141,6 @@ func TestNil(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Consul works.
 func TestClose(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Consul could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 	err := client.Close()
 	if err != nil {

--- a/consul/consul_test.go
+++ b/consul/consul_test.go
@@ -15,8 +15,6 @@ import (
 
 // TestClient tests if reading from, writing to and deleting from the store works properly.
 // A struct is used as value. See TestTypes() for a test that is simpler but tests all types.
-//
-// Note: This test is only executed if the initial connection to Consul works.
 func TestClient(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -32,8 +30,6 @@ func TestClient(t *testing.T) {
 }
 
 // TestTypes tests if setting and getting values works with all Go types.
-//
-// Note: This test is only executed if the initial connection to Consul works.
 func TestTypes(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -49,8 +45,6 @@ func TestTypes(t *testing.T) {
 }
 
 // TestClientConcurrent launches a bunch of goroutines that concurrently work with the Consul client.
-//
-// Note: This test is only executed if the initial connection to Consul works.
 func TestClientConcurrent(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 
@@ -62,8 +56,6 @@ func TestClientConcurrent(t *testing.T) {
 }
 
 // TestErrors tests some error cases.
-//
-// Note: This test is only executed if the initial connection to Consul works.
 func TestErrors(t *testing.T) {
 	// Test empty key
 	client := createClient(t, encoding.JSON)
@@ -82,8 +74,6 @@ func TestErrors(t *testing.T) {
 }
 
 // TestNil tests the behaviour when passing nil or pointers to nil values to some methods.
-//
-// Note: This test is only executed if the initial connection to Consul works.
 func TestNil(t *testing.T) {
 	// Test setting nil
 
@@ -138,8 +128,6 @@ func TestNil(t *testing.T) {
 }
 
 // TestClose tests if the close method returns any errors.
-//
-// Note: This test is only executed if the initial connection to Consul works.
 func TestClose(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 	err := client.Close()

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -16,8 +16,6 @@ import (
 
 // TestClient tests if reading from, writing to and deleting from the store works properly.
 // A struct is used as value. See TestTypes() for a test that is simpler but tests all types.
-//
-// Note: This test is only executed if the initial connection to Cloud Datastore works.
 func TestClient(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -35,8 +33,6 @@ func TestClient(t *testing.T) {
 }
 
 // TestTypes tests if setting and getting values works with all Go types.
-//
-// Note: This test is only executed if the initial connection to Cloud Datastore works.
 func TestTypes(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -54,8 +50,6 @@ func TestTypes(t *testing.T) {
 }
 
 // TestClientConcurrent launches a bunch of goroutines that concurrently work with the Cloud Datastore client.
-//
-// Note: This test is only executed if the initial connection to Cloud Datastore works.
 func TestClientConcurrent(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 	defer client.Close()
@@ -69,8 +63,6 @@ func TestClientConcurrent(t *testing.T) {
 }
 
 // TestErrors tests some error cases.
-//
-// Note: This test is only executed if the initial connection to Cloud Datastore works.
 func TestErrors(t *testing.T) {
 	// Test empty key
 	client := createClient(t, encoding.JSON)
@@ -90,8 +82,6 @@ func TestErrors(t *testing.T) {
 }
 
 // TestNil tests the behaviour when passing nil or pointers to nil values to some methods.
-//
-// Note: This test is only executed if the initial connection to Cloud Datastore works.
 func TestNil(t *testing.T) {
 	// Test setting nil
 
@@ -149,8 +139,6 @@ func TestNil(t *testing.T) {
 }
 
 // TestClose tests if the close method returns any errors.
-//
-// Note: This test is only executed if the initial connection to Cloud Datastore works.
 func TestClose(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 	err := client.Close()

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -19,10 +19,6 @@ import (
 //
 // Note: This test is only executed if the initial connection to Cloud Datastore works.
 func TestClient(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Cloud Datastore could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -42,10 +38,6 @@ func TestClient(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Cloud Datastore works.
 func TestTypes(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Cloud Datastore could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -65,10 +57,6 @@ func TestTypes(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Cloud Datastore works.
 func TestClientConcurrent(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Cloud Datastore could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 	defer client.Close()
 
@@ -84,10 +72,6 @@ func TestClientConcurrent(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Cloud Datastore works.
 func TestErrors(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Cloud Datastore could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test empty key
 	client := createClient(t, encoding.JSON)
 	defer client.Close()
@@ -109,10 +93,6 @@ func TestErrors(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Cloud Datastore works.
 func TestNil(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Cloud Datastore could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test setting nil
 
 	t.Run("set nil with JSON marshalling", func(t *testing.T) {
@@ -172,10 +152,6 @@ func TestNil(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Cloud Datastore works.
 func TestClose(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Cloud Datastore could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 	err := client.Close()
 	if err != nil {

--- a/dynamodb/dynamodb_test.go
+++ b/dynamodb/dynamodb_test.go
@@ -31,8 +31,6 @@ func TestConnection(t *testing.T) {
 
 // TestClient tests if reading from, writing to and deleting from the store works properly.
 // A struct is used as value. See TestTypes() for a test that is simpler but tests all types.
-//
-// Note: This test is only executed if the initial connection to DynamoDB works.
 func TestClient(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -48,8 +46,6 @@ func TestClient(t *testing.T) {
 }
 
 // TestTypes tests if setting and getting values works with all Go types.
-//
-// Note: This test is only executed if the initial connection to DynamoDB works.
 func TestTypes(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -65,8 +61,6 @@ func TestTypes(t *testing.T) {
 }
 
 // TestClientConcurrent launches a bunch of goroutines that concurrently work with the DynamoDB client.
-//
-// Note: This test is only executed if the initial connection to DynamoDB works.
 func TestClientConcurrent(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 
@@ -76,8 +70,6 @@ func TestClientConcurrent(t *testing.T) {
 }
 
 // TestErrors tests some error cases.
-//
-// Note: This test is only executed if the initial connection to DynamoDB works.
 func TestErrors(t *testing.T) {
 	// Test empty key
 	client := createClient(t, encoding.JSON)
@@ -122,8 +114,6 @@ func TestErrors(t *testing.T) {
 }
 
 // TestNil tests the behaviour when passing nil or pointers to nil values to some methods.
-//
-// Note: This test is only executed if the initial connection to DynamoDB works.
 func TestNil(t *testing.T) {
 	// Test setting nil
 
@@ -178,8 +168,6 @@ func TestNil(t *testing.T) {
 }
 
 // TestClose tests if the close method returns any errors.
-//
-// Note: This test is only executed if the initial connection to DynamoDB works.
 func TestClose(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 	err := client.Close()

--- a/dynamodb/dynamodb_test.go
+++ b/dynamodb/dynamodb_test.go
@@ -34,10 +34,6 @@ func TestConnection(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to DynamoDB works.
 func TestClient(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to DynamoDB could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -55,10 +51,6 @@ func TestClient(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to DynamoDB works.
 func TestTypes(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to DynamoDB could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -76,10 +68,6 @@ func TestTypes(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to DynamoDB works.
 func TestClientConcurrent(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to DynamoDB could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 
 	goroutineCount := 1000
@@ -91,10 +79,6 @@ func TestClientConcurrent(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to DynamoDB works.
 func TestErrors(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to DynamoDB could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test empty key
 	client := createClient(t, encoding.JSON)
 	err := client.Set("", "bar")
@@ -141,10 +125,6 @@ func TestErrors(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to DynamoDB works.
 func TestNil(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to DynamoDB could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test setting nil
 
 	t.Run("set nil with JSON marshalling", func(t *testing.T) {
@@ -201,10 +181,6 @@ func TestNil(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to DynamoDB works.
 func TestClose(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to DynamoDB could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 	err := client.Close()
 	if err != nil {

--- a/etcd/etcd_test.go
+++ b/etcd/etcd_test.go
@@ -19,10 +19,6 @@ import (
 //
 // Note: This test is only executed if the initial connection to etcd works.
 func TestClient(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to etcd could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -42,10 +38,6 @@ func TestClient(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to etcd works.
 func TestTypes(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to etcd could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -65,9 +57,6 @@ func TestTypes(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to etcd works.
 func TestClientConcurrent(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to etcd could be established. Probably not running in a proper test environment.")
-	}
 	// This test always works locally, but depending on the time of day, maybe
 	// depending on how busy GitHub Action infra is, it has issues in CI.
 	// It fails with connection resets and timeouts.
@@ -90,10 +79,6 @@ func TestClientConcurrent(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to etcd works.
 func TestErrors(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to etcd could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test empty key
 	client := createClient(t, encoding.JSON)
 	defer client.Close()
@@ -115,10 +100,6 @@ func TestErrors(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to etcd works.
 func TestNil(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to etcd could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test setting nil
 
 	t.Run("set nil with JSON marshalling", func(t *testing.T) {
@@ -178,10 +159,6 @@ func TestNil(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to etcd works.
 func TestClose(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to etcd could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 	err := client.Close()
 	if err != nil {
@@ -195,10 +172,6 @@ func TestClose(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Memcached works.
 func TestDefaultTimeout(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to etcd could be established. Probably not running in a proper test environment.")
-	}
-
 	options := etcd.Options{}
 	client, err := etcd.NewClient(options)
 	if err != nil {

--- a/etcd/etcd_test.go
+++ b/etcd/etcd_test.go
@@ -16,8 +16,6 @@ import (
 
 // TestClient tests if reading from, writing to and deleting from the store works properly.
 // A struct is used as value. See TestTypes() for a test that is simpler but tests all types.
-//
-// Note: This test is only executed if the initial connection to etcd works.
 func TestClient(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -35,8 +33,6 @@ func TestClient(t *testing.T) {
 }
 
 // TestTypes tests if setting and getting values works with all Go types.
-//
-// Note: This test is only executed if the initial connection to etcd works.
 func TestTypes(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -54,8 +50,6 @@ func TestTypes(t *testing.T) {
 }
 
 // TestClientConcurrent launches a bunch of goroutines that concurrently work with the etcd client.
-//
-// Note: This test is only executed if the initial connection to etcd works.
 func TestClientConcurrent(t *testing.T) {
 	// This test always works locally, but depending on the time of day, maybe
 	// depending on how busy GitHub Action infra is, it has issues in CI.
@@ -76,8 +70,6 @@ func TestClientConcurrent(t *testing.T) {
 }
 
 // TestErrors tests some error cases.
-//
-// Note: This test is only executed if the initial connection to etcd works.
 func TestErrors(t *testing.T) {
 	// Test empty key
 	client := createClient(t, encoding.JSON)
@@ -97,8 +89,6 @@ func TestErrors(t *testing.T) {
 }
 
 // TestNil tests the behaviour when passing nil or pointers to nil values to some methods.
-//
-// Note: This test is only executed if the initial connection to etcd works.
 func TestNil(t *testing.T) {
 	// Test setting nil
 
@@ -156,8 +146,6 @@ func TestNil(t *testing.T) {
 }
 
 // TestClose tests if the close method returns any errors.
-//
-// Note: This test is only executed if the initial connection to etcd works.
 func TestClose(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 	err := client.Close()
@@ -169,8 +157,6 @@ func TestClose(t *testing.T) {
 // TestDefaultTimeout tests if the client works with the default timeout.
 // Currently, the createClient() method is used in other tests,
 // which sets the timeout to 2 seconds due to errors during the concurrency test.
-//
-// Note: This test is only executed if the initial connection to Memcached works.
 func TestDefaultTimeout(t *testing.T) {
 	options := etcd.Options{}
 	client, err := etcd.NewClient(options)

--- a/hazelcast/hazelcast_test.go
+++ b/hazelcast/hazelcast_test.go
@@ -15,8 +15,6 @@ import (
 
 // TestClient tests if reading from, writing to and deleting from the store works properly.
 // A struct is used as value. See TestTypes() for a test that is simpler but tests all types.
-//
-// Note: This test is only executed if the initial connection to Hazelcast works.
 func TestClient(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -32,8 +30,6 @@ func TestClient(t *testing.T) {
 }
 
 // TestTypes tests if setting and getting values works with all Go types.
-//
-// Note: This test is only executed if the initial connection to Hazelcast works.
 func TestTypes(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -49,8 +45,6 @@ func TestTypes(t *testing.T) {
 }
 
 // TestClientConcurrent launches a bunch of goroutines that concurrently work with the Hazelcast client.
-//
-// Note: This test is only executed if the initial connection to Hazelcast works.
 func TestClientConcurrent(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 
@@ -60,8 +54,6 @@ func TestClientConcurrent(t *testing.T) {
 }
 
 // TestErrors tests some error cases.
-//
-// Note: This test is only executed if the initial connection to Hazelcast works.
 func TestErrors(t *testing.T) {
 	// Test empty key
 	client := createClient(t, encoding.JSON)
@@ -80,8 +72,6 @@ func TestErrors(t *testing.T) {
 }
 
 // TestNil tests the behaviour when passing nil or pointers to nil values to some methods.
-//
-// Note: This test is only executed if the initial connection to Hazelcast works.
 func TestNil(t *testing.T) {
 	// Test setting nil
 
@@ -136,8 +126,6 @@ func TestNil(t *testing.T) {
 }
 
 // TestClose tests if the close method returns any errors.
-//
-// Note: This test is only executed if the initial connection to Hazelcast works.
 func TestClose(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 	err := client.Close()

--- a/hazelcast/hazelcast_test.go
+++ b/hazelcast/hazelcast_test.go
@@ -18,10 +18,6 @@ import (
 //
 // Note: This test is only executed if the initial connection to Hazelcast works.
 func TestClient(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Hazelcast could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -39,10 +35,6 @@ func TestClient(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Hazelcast works.
 func TestTypes(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Hazelcast could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -60,10 +52,6 @@ func TestTypes(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Hazelcast works.
 func TestClientConcurrent(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Hazelcast could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 
 	goroutineCount := 1000
@@ -75,10 +63,6 @@ func TestClientConcurrent(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Hazelcast works.
 func TestErrors(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Hazelcast could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test empty key
 	client := createClient(t, encoding.JSON)
 	err := client.Set("", "bar")
@@ -99,10 +83,6 @@ func TestErrors(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Hazelcast works.
 func TestNil(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Hazelcast could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test setting nil
 
 	t.Run("set nil with JSON marshalling", func(t *testing.T) {
@@ -159,10 +139,6 @@ func TestNil(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Hazelcast works.
 func TestClose(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Hazelcast could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 	err := client.Close()
 	if err != nil {

--- a/ignite/ignite_test.go
+++ b/ignite/ignite_test.go
@@ -18,10 +18,6 @@ import (
 //
 // Note: This test is only executed if the initial connection to Apache Ignite works.
 func TestClient(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Apache Ignite could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -41,10 +37,6 @@ func TestClient(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Apache Ignite works.
 func TestTypes(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Apache Ignite could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -64,10 +56,6 @@ func TestTypes(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Apache Ignite works.
 func TestClientConcurrent(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Apache Ignite could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 	defer client.Close()
 
@@ -80,10 +68,6 @@ func TestClientConcurrent(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Apache Ignite works.
 func TestErrors(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Apache Ignite could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test empty key
 	client := createClient(t, encoding.JSON)
 	defer client.Close()
@@ -105,10 +89,6 @@ func TestErrors(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Apache Ignite works.
 func TestNil(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Apache Ignite could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test setting nil
 
 	t.Run("set nil with JSON marshalling", func(t *testing.T) {
@@ -168,10 +148,6 @@ func TestNil(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Apache Ignite works.
 func TestClose(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Apache Ignite could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 	err := client.Close()
 	if err != nil {

--- a/ignite/ignite_test.go
+++ b/ignite/ignite_test.go
@@ -15,8 +15,6 @@ import (
 
 // TestClient tests if reading from, writing to and deleting from the store works properly.
 // A struct is used as value. See TestTypes() for a test that is simpler but tests all types.
-//
-// Note: This test is only executed if the initial connection to Apache Ignite works.
 func TestClient(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -34,8 +32,6 @@ func TestClient(t *testing.T) {
 }
 
 // TestTypes tests if setting and getting values works with all Go types.
-//
-// Note: This test is only executed if the initial connection to Apache Ignite works.
 func TestTypes(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -53,8 +49,6 @@ func TestTypes(t *testing.T) {
 }
 
 // TestClientConcurrent launches a bunch of goroutines that concurrently work with the Apache Ignite client.
-//
-// Note: This test is only executed if the initial connection to Apache Ignite works.
 func TestClientConcurrent(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 	defer client.Close()
@@ -65,8 +59,6 @@ func TestClientConcurrent(t *testing.T) {
 }
 
 // TestErrors tests some error cases.
-//
-// Note: This test is only executed if the initial connection to Apache Ignite works.
 func TestErrors(t *testing.T) {
 	// Test empty key
 	client := createClient(t, encoding.JSON)
@@ -86,8 +78,6 @@ func TestErrors(t *testing.T) {
 }
 
 // TestNil tests the behaviour when passing nil or pointers to nil values to some methods.
-//
-// Note: This test is only executed if the initial connection to Apache Ignite works.
 func TestNil(t *testing.T) {
 	// Test setting nil
 
@@ -145,8 +135,6 @@ func TestNil(t *testing.T) {
 }
 
 // TestClose tests if the close method returns any errors.
-//
-// Note: This test is only executed if the initial connection to Apache Ignite works.
 func TestClose(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 	err := client.Close()

--- a/memcached/memcached_test.go
+++ b/memcached/memcached_test.go
@@ -17,10 +17,6 @@ import (
 //
 // Note: This test is only executed if the initial connection to Memcached works.
 func TestClient(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Memcached could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -38,10 +34,6 @@ func TestClient(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Memcached works.
 func TestTypes(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Memcached could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -59,10 +51,6 @@ func TestTypes(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Memcached works.
 func TestClientConcurrent(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Memcached could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 
 	// TODO: 1000 leads to timeout errors every time.
@@ -76,10 +64,6 @@ func TestClientConcurrent(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Memcached works.
 func TestErrors(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Memcached could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test empty key
 	client := createClient(t, encoding.JSON)
 	err := client.Set("", "bar")
@@ -100,10 +84,6 @@ func TestErrors(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Memcached works.
 func TestNil(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Memcached could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test setting nil
 
 	t.Run("set nil with JSON marshalling", func(t *testing.T) {
@@ -160,10 +140,6 @@ func TestNil(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Memcached works.
 func TestClose(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Memcached could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 	err := client.Close()
 	if err != nil {
@@ -177,10 +153,6 @@ func TestClose(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Memcached works.
 func TestDefaultTimeout(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Memcached could be established. Probably not running in a proper test environment.")
-	}
-
 	options := memcached.Options{}
 	client, err := memcached.NewClient(options)
 	if err != nil {

--- a/memcached/memcached_test.go
+++ b/memcached/memcached_test.go
@@ -14,8 +14,6 @@ import (
 
 // TestClient tests if reading from, writing to and deleting from the store works properly.
 // A struct is used as value. See TestTypes() for a test that is simpler but tests all types.
-//
-// Note: This test is only executed if the initial connection to Memcached works.
 func TestClient(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -31,8 +29,6 @@ func TestClient(t *testing.T) {
 }
 
 // TestTypes tests if setting and getting values works with all Go types.
-//
-// Note: This test is only executed if the initial connection to Memcached works.
 func TestTypes(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -48,8 +44,6 @@ func TestTypes(t *testing.T) {
 }
 
 // TestClientConcurrent launches a bunch of goroutines that concurrently work with the Memcached client.
-//
-// Note: This test is only executed if the initial connection to Memcached works.
 func TestClientConcurrent(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 
@@ -61,8 +55,6 @@ func TestClientConcurrent(t *testing.T) {
 }
 
 // TestErrors tests some error cases.
-//
-// Note: This test is only executed if the initial connection to Memcached works.
 func TestErrors(t *testing.T) {
 	// Test empty key
 	client := createClient(t, encoding.JSON)
@@ -81,8 +73,6 @@ func TestErrors(t *testing.T) {
 }
 
 // TestNil tests the behaviour when passing nil or pointers to nil values to some methods.
-//
-// Note: This test is only executed if the initial connection to Memcached works.
 func TestNil(t *testing.T) {
 	// Test setting nil
 
@@ -137,8 +127,6 @@ func TestNil(t *testing.T) {
 }
 
 // TestClose tests if the close method returns any errors.
-//
-// Note: This test is only executed if the initial connection to Memcached works.
 func TestClose(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 	err := client.Close()
@@ -150,8 +138,6 @@ func TestClose(t *testing.T) {
 // TestDefaultTimeout tests if the client works with the default timeout.
 // Currently, the createClient() method is used in other tests,
 // which sets the timeout to 2 seconds due to errors during the concurrency test.
-//
-// Note: This test is only executed if the initial connection to Memcached works.
 func TestDefaultTimeout(t *testing.T) {
 	options := memcached.Options{}
 	client, err := memcached.NewClient(options)

--- a/mongodb/mongodb_test.go
+++ b/mongodb/mongodb_test.go
@@ -21,10 +21,6 @@ import (
 //
 // Note: This test is only executed if the initial connection to MongoDB works.
 func TestClient(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to MongoDB could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -44,10 +40,6 @@ func TestClient(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to MongoDB works.
 func TestTypes(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to MongoDB could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -67,10 +59,6 @@ func TestTypes(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to MongoDB works.
 func TestClientConcurrent(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to MongoDB could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 	defer client.Close()
 
@@ -83,10 +71,6 @@ func TestClientConcurrent(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to MongoDB works.
 func TestErrors(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to MongoDB could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test empty key
 	client := createClient(t, encoding.JSON)
 	defer client.Close()
@@ -117,10 +101,6 @@ func TestErrors(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to MongoDB works.
 func TestNil(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to MongoDB could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test setting nil
 
 	t.Run("set nil with JSON marshalling", func(t *testing.T) {
@@ -180,10 +160,6 @@ func TestNil(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to MongoDB works.
 func TestClose(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to MongoDB could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 	err := client.Close()
 	if err != nil {

--- a/mongodb/mongodb_test.go
+++ b/mongodb/mongodb_test.go
@@ -18,8 +18,6 @@ import (
 
 // TestClient tests if reading from, writing to and deleting from the store works properly.
 // A struct is used as value. See TestTypes() for a test that is simpler but tests all types.
-//
-// Note: This test is only executed if the initial connection to MongoDB works.
 func TestClient(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -37,8 +35,6 @@ func TestClient(t *testing.T) {
 }
 
 // TestTypes tests if setting and getting values works with all Go types.
-//
-// Note: This test is only executed if the initial connection to MongoDB works.
 func TestTypes(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -56,8 +52,6 @@ func TestTypes(t *testing.T) {
 }
 
 // TestClientConcurrent launches a bunch of goroutines that concurrently work with the MongoDB client.
-//
-// Note: This test is only executed if the initial connection to MongoDB works.
 func TestClientConcurrent(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 	defer client.Close()
@@ -68,8 +62,6 @@ func TestClientConcurrent(t *testing.T) {
 }
 
 // TestErrors tests some error cases.
-//
-// Note: This test is only executed if the initial connection to MongoDB works.
 func TestErrors(t *testing.T) {
 	// Test empty key
 	client := createClient(t, encoding.JSON)
@@ -98,8 +90,6 @@ func TestErrors(t *testing.T) {
 }
 
 // TestNil tests the behaviour when passing nil or pointers to nil values to some methods.
-//
-// Note: This test is only executed if the initial connection to MongoDB works.
 func TestNil(t *testing.T) {
 	// Test setting nil
 
@@ -157,8 +147,6 @@ func TestNil(t *testing.T) {
 }
 
 // TestClose tests if the close method returns any errors.
-//
-// Note: This test is only executed if the initial connection to MongoDB works.
 func TestClose(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 	err := client.Close()

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -3,6 +3,7 @@ package mysql_test
 import (
 	"database/sql"
 	"log"
+	"os"
 	"testing"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -14,11 +15,10 @@ import (
 
 // TestClient tests if reading from, writing to and deleting from the store works properly.
 // A struct is used as value. See TestTypes() for a test that is simpler but tests all types.
-//
-// Note: This test is only executed if the initial connection to MySQL works.
 func TestClient(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to MySQL could be established. Probably not running in a proper test environment.")
+	// For some reason this test fails in GitHub Actions, but not locally.
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		t.Skip("Skipping test in GitHub Actions. Run this locally before a release!")
 	}
 
 	// Test with JSON
@@ -37,11 +37,10 @@ func TestClient(t *testing.T) {
 }
 
 // TestTypes tests if setting and getting values works with all Go types.
-//
-// Note: This test is only executed if the initial connection to MySQL works.
 func TestTypes(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to MySQL could be established. Probably not running in a proper test environment.")
+	// For some reason this test fails in GitHub Actions, but not locally.
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		t.Skip("Skipping test in GitHub Actions. Run this locally before a release!")
 	}
 
 	// Test with JSON
@@ -60,13 +59,11 @@ func TestTypes(t *testing.T) {
 }
 
 // TestClientConcurrent launches a bunch of goroutines that concurrently work with the MySQL client.
-//
-// Note: This test is only executed if the initial connection to MySQL works.
 func TestClientConcurrent(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to MySQL could be established. Probably not running in a proper test environment.")
+	// For some reason this test fails in GitHub Actions, but not locally.
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		t.Skip("Skipping test in GitHub Actions. Run this locally before a release!")
 	}
-
 	client := createClient(t, encoding.JSON)
 	defer client.Close()
 
@@ -76,11 +73,10 @@ func TestClientConcurrent(t *testing.T) {
 }
 
 // TestErrors tests some error cases.
-//
-// Note: This test is only executed if the initial connection to MySQL works.
 func TestErrors(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to MySQL could be established. Probably not running in a proper test environment.")
+	// For some reason this test fails in GitHub Actions, but not locally.
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		t.Skip("Skipping test in GitHub Actions. Run this locally before a release!")
 	}
 
 	// Test empty key
@@ -101,11 +97,10 @@ func TestErrors(t *testing.T) {
 }
 
 // TestNil tests the behaviour when passing nil or pointers to nil values to some methods.
-//
-// Note: This test is only executed if the initial connection to MySQL works.
 func TestNil(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to MySQL could be established. Probably not running in a proper test environment.")
+	// For some reason this test fails in GitHub Actions, but not locally.
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		t.Skip("Skipping test in GitHub Actions. Run this locally before a release!")
 	}
 
 	// Test setting nil
@@ -166,11 +161,10 @@ func TestNil(t *testing.T) {
 // TestDBcreation tests if the DB gets created successfully when the DSN doesn't contain one.
 // The other tests call createClient, which doesn't use any DSN,
 // which leads to the gokv implementation to use "root@/gokv" by default.
-//
-// Note: This test is only executed if the initial connection to MySQL works.
 func TestDBcreation(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to MySQL could be established. Probably not running in a proper test environment.")
+	// For some reason this test fails in GitHub Actions, but not locally.
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		t.Skip("Skipping test in GitHub Actions. Run this locally before a release!")
 	}
 
 	options := mysql.Options{
@@ -200,11 +194,10 @@ func TestDBcreation(t *testing.T) {
 }
 
 // TestClose tests if the close method returns any errors.
-//
-// Note: This test is only executed if the initial connection to MySQL works.
 func TestClose(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to MySQL could be established. Probably not running in a proper test environment.")
+	// For some reason this test fails in GitHub Actions, but not locally.
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		t.Skip("Skipping test in GitHub Actions. Run this locally before a release!")
 	}
 
 	client := createClient(t, encoding.JSON)
@@ -214,10 +207,10 @@ func TestClose(t *testing.T) {
 	}
 }
 
-// Note: This test is only executed if the initial connection to MySQL works.
 func TestDefaultMaxOpenConnections(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to MySQL could be established. Probably not running in a proper test environment.")
+	// For some reason this test fails in GitHub Actions, but not locally.
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		t.Skip("Skipping test in GitHub Actions. Run this locally before a release!")
 	}
 
 	options := mysql.Options{}

--- a/postgresql/postgresql_test.go
+++ b/postgresql/postgresql_test.go
@@ -12,8 +12,6 @@ import (
 
 // TestClient tests if reading from, writing to and deleting from the store works properly.
 // A struct is used as value. See TestTypes() for a test that is simpler but tests all types.
-//
-// Note: This test is only executed if the initial connection to PostgreSQL works.
 func TestClient(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -29,8 +27,6 @@ func TestClient(t *testing.T) {
 }
 
 // TestTypes tests if setting and getting values works with all Go types.
-//
-// Note: This test is only executed if the initial connection to PostgreSQL works.
 func TestTypes(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -46,8 +42,6 @@ func TestTypes(t *testing.T) {
 }
 
 // TestClientConcurrent launches a bunch of goroutines that concurrently work with the PostgreSQL client.
-//
-// Note: This test is only executed if the initial connection to PostgreSQL works.
 func TestClientConcurrent(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 
@@ -57,8 +51,6 @@ func TestClientConcurrent(t *testing.T) {
 }
 
 // TestErrors tests some error cases.
-//
-// Note: This test is only executed if the initial connection to PostgreSQL works.
 func TestErrors(t *testing.T) {
 	// Test empty key
 	client := createClient(t, encoding.JSON)
@@ -94,8 +86,6 @@ func TestErrors(t *testing.T) {
 }
 
 // TestNil tests the behaviour when passing nil or pointers to nil values to some methods.
-//
-// Note: This test is only executed if the initial connection to PostgreSQL works.
 func TestNil(t *testing.T) {
 	// Test setting nil
 
@@ -153,8 +143,6 @@ func TestNil(t *testing.T) {
 }
 
 // TestClose tests if the close method returns any errors.
-//
-// Note: This test is only executed if the initial connection to PostgreSQL works.
 func TestClose(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 	defer client.Close()

--- a/postgresql/postgresql_test.go
+++ b/postgresql/postgresql_test.go
@@ -15,10 +15,6 @@ import (
 //
 // Note: This test is only executed if the initial connection to PostgreSQL works.
 func TestClient(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to PostgreSQL could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -36,10 +32,6 @@ func TestClient(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to PostgreSQL works.
 func TestTypes(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to PostgreSQL could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -57,10 +49,6 @@ func TestTypes(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to PostgreSQL works.
 func TestClientConcurrent(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to PostgreSQL could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 
 	goroutineCount := 1000
@@ -72,10 +60,6 @@ func TestClientConcurrent(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to PostgreSQL works.
 func TestErrors(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to PostgreSQL could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test empty key
 	client := createClient(t, encoding.JSON)
 	err := client.Set("", "bar")
@@ -113,10 +97,6 @@ func TestErrors(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to PostgreSQL works.
 func TestNil(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to PostgreSQL could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test setting nil
 
 	t.Run("set nil with JSON marshalling", func(t *testing.T) {
@@ -176,10 +156,6 @@ func TestNil(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to PostgreSQL works.
 func TestClose(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to PostgreSQL could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 	defer client.Close()
 	err := client.Close()

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -18,8 +18,6 @@ var testDbNumber = 15 // 16 DBs by default (unchanged config), starting with 0
 
 // TestClient tests if reading from, writing to and deleting from the store works properly.
 // A struct is used as value. See TestTypes() for a test that is simpler but tests all types.
-//
-// Note: This test is only executed if the initial connection to Redis works.
 func TestClient(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -37,8 +35,6 @@ func TestClient(t *testing.T) {
 }
 
 // TestTypes tests if setting and getting values works with all Go types.
-//
-// Note: This test is only executed if the initial connection to Redis works.
 func TestTypes(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -56,8 +52,6 @@ func TestTypes(t *testing.T) {
 }
 
 // TestClientConcurrent launches a bunch of goroutines that concurrently work with the Redis client.
-//
-// Note: This test is only executed if the initial connection to Redis works.
 func TestClientConcurrent(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 	defer client.Close()
@@ -68,8 +62,6 @@ func TestClientConcurrent(t *testing.T) {
 }
 
 // TestErrors tests some error cases.
-//
-// Note: This test is only executed if the initial connection to Redis works.
 func TestErrors(t *testing.T) {
 	// Test empty key
 	client := createClient(t, encoding.JSON)
@@ -89,8 +81,6 @@ func TestErrors(t *testing.T) {
 }
 
 // TestNil tests the behaviour when passing nil or pointers to nil values to some methods.
-//
-// Note: This test is only executed if the initial connection to Redis works.
 func TestNil(t *testing.T) {
 	// Test setting nil
 
@@ -148,8 +138,6 @@ func TestNil(t *testing.T) {
 }
 
 // TestClose tests if the close method returns any errors.
-//
-// Note: This test is only executed if the initial connection to Redis works.
 func TestClose(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 	err := client.Close()

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -21,10 +21,6 @@ var testDbNumber = 15 // 16 DBs by default (unchanged config), starting with 0
 //
 // Note: This test is only executed if the initial connection to Redis works.
 func TestClient(t *testing.T) {
-	if !checkConnection(testDbNumber) {
-		t.Skip("No connection to Redis could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -44,10 +40,6 @@ func TestClient(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Redis works.
 func TestTypes(t *testing.T) {
-	if !checkConnection(testDbNumber) {
-		t.Skip("No connection to Redis could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -67,10 +59,6 @@ func TestTypes(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Redis works.
 func TestClientConcurrent(t *testing.T) {
-	if !checkConnection(testDbNumber) {
-		t.Skip("No connection to Redis could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 	defer client.Close()
 
@@ -83,10 +71,6 @@ func TestClientConcurrent(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Redis works.
 func TestErrors(t *testing.T) {
-	if !checkConnection(testDbNumber) {
-		t.Skip("No connection to Redis could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test empty key
 	client := createClient(t, encoding.JSON)
 	defer client.Close()
@@ -108,10 +92,6 @@ func TestErrors(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Redis works.
 func TestNil(t *testing.T) {
-	if !checkConnection(testDbNumber) {
-		t.Skip("No connection to Redis could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test setting nil
 
 	t.Run("set nil with JSON marshalling", func(t *testing.T) {
@@ -171,10 +151,6 @@ func TestNil(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Redis works.
 func TestClose(t *testing.T) {
-	if !checkConnection(testDbNumber) {
-		t.Skip("No connection to Redis could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 	err := client.Close()
 	if err != nil {

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -25,10 +25,6 @@ var customEndpoint = "http://localhost:9000"
 //
 // Note: This test is only executed if the initial connection to S3 works.
 func TestClient(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to S3 could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -46,10 +42,6 @@ func TestClient(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to S3 works.
 func TestTypes(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to S3 could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -67,10 +59,6 @@ func TestTypes(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to S3 works.
 func TestClientConcurrent(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to S3 could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 
 	goroutineCount := 1000
@@ -82,10 +70,6 @@ func TestClientConcurrent(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to S3 works.
 func TestErrors(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to S3 could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test empty key
 	client := createClient(t, encoding.JSON)
 	err := client.Set("", "bar")
@@ -143,10 +127,6 @@ func TestErrors(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to S3 works.
 func TestNil(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to S3 could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test setting nil
 
 	t.Run("set nil with JSON marshalling", func(t *testing.T) {
@@ -203,10 +183,6 @@ func TestNil(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to S3 works.
 func TestClose(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to S3 could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 	err := client.Close()
 	if err != nil {

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -22,8 +22,6 @@ var customEndpoint = "http://localhost:9000"
 
 // TestClient tests if reading from, writing to and deleting from the store works properly.
 // A struct is used as value. See TestTypes() for a test that is simpler but tests all types.
-//
-// Note: This test is only executed if the initial connection to S3 works.
 func TestClient(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -39,8 +37,6 @@ func TestClient(t *testing.T) {
 }
 
 // TestTypes tests if setting and getting values works with all Go types.
-//
-// Note: This test is only executed if the initial connection to S3 works.
 func TestTypes(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -56,8 +52,6 @@ func TestTypes(t *testing.T) {
 }
 
 // TestClientConcurrent launches a bunch of goroutines that concurrently work with the S3 client.
-//
-// Note: This test is only executed if the initial connection to S3 works.
 func TestClientConcurrent(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 
@@ -67,8 +61,6 @@ func TestClientConcurrent(t *testing.T) {
 }
 
 // TestErrors tests some error cases.
-//
-// Note: This test is only executed if the initial connection to S3 works.
 func TestErrors(t *testing.T) {
 	// Test empty key
 	client := createClient(t, encoding.JSON)
@@ -124,8 +116,6 @@ func TestErrors(t *testing.T) {
 }
 
 // TestNil tests the behaviour when passing nil or pointers to nil values to some methods.
-//
-// Note: This test is only executed if the initial connection to S3 works.
 func TestNil(t *testing.T) {
 	// Test setting nil
 
@@ -180,8 +170,6 @@ func TestNil(t *testing.T) {
 }
 
 // TestClose tests if the close method returns any errors.
-//
-// Note: This test is only executed if the initial connection to S3 works.
 func TestClose(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 	err := client.Close()

--- a/zookeeper/zookeeper_test.go
+++ b/zookeeper/zookeeper_test.go
@@ -18,10 +18,6 @@ import (
 //
 // Note: This test is only executed if the initial connection to Apache ZooKeeper works.
 func TestClient(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Apache ZooKeeper could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -41,10 +37,6 @@ func TestClient(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Apache ZooKeeper works.
 func TestTypes(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Apache ZooKeeper could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
 		client := createClient(t, encoding.JSON)
@@ -64,10 +56,6 @@ func TestTypes(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Apache ZooKeeper works.
 func TestClientConcurrent(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Apache ZooKeeper could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 	defer client.Close()
 
@@ -80,10 +68,6 @@ func TestClientConcurrent(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Apache ZooKeeper works.
 func TestErrors(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Apache ZooKeeper could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test empty key
 	client := createClient(t, encoding.JSON)
 	defer client.Close()
@@ -114,10 +98,6 @@ func TestErrors(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Apache ZooKeeper works.
 func TestNil(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Apache ZooKeeper could be established. Probably not running in a proper test environment.")
-	}
-
 	// Test setting nil
 
 	t.Run("set nil with JSON marshalling", func(t *testing.T) {
@@ -177,10 +157,6 @@ func TestNil(t *testing.T) {
 //
 // Note: This test is only executed if the initial connection to Apache ZooKeeper works.
 func TestClose(t *testing.T) {
-	if !checkConnection() {
-		t.Skip("No connection to Apache ZooKeeper could be established. Probably not running in a proper test environment.")
-	}
-
 	client := createClient(t, encoding.JSON)
 	err := client.Close()
 	if err != nil {

--- a/zookeeper/zookeeper_test.go
+++ b/zookeeper/zookeeper_test.go
@@ -15,8 +15,6 @@ import (
 
 // TestClient tests if reading from, writing to and deleting from the store works properly.
 // A struct is used as value. See TestTypes() for a test that is simpler but tests all types.
-//
-// Note: This test is only executed if the initial connection to Apache ZooKeeper works.
 func TestClient(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -34,8 +32,6 @@ func TestClient(t *testing.T) {
 }
 
 // TestTypes tests if setting and getting values works with all Go types.
-//
-// Note: This test is only executed if the initial connection to Apache ZooKeeper works.
 func TestTypes(t *testing.T) {
 	// Test with JSON
 	t.Run("JSON", func(t *testing.T) {
@@ -53,8 +49,6 @@ func TestTypes(t *testing.T) {
 }
 
 // TestClientConcurrent launches a bunch of goroutines that concurrently work with the Apache ZooKeeper client.
-//
-// Note: This test is only executed if the initial connection to Apache ZooKeeper works.
 func TestClientConcurrent(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 	defer client.Close()
@@ -65,8 +59,6 @@ func TestClientConcurrent(t *testing.T) {
 }
 
 // TestErrors tests some error cases.
-//
-// Note: This test is only executed if the initial connection to Apache ZooKeeper works.
 func TestErrors(t *testing.T) {
 	// Test empty key
 	client := createClient(t, encoding.JSON)
@@ -95,8 +87,6 @@ func TestErrors(t *testing.T) {
 }
 
 // TestNil tests the behaviour when passing nil or pointers to nil values to some methods.
-//
-// Note: This test is only executed if the initial connection to Apache ZooKeeper works.
 func TestNil(t *testing.T) {
 	// Test setting nil
 
@@ -154,8 +144,6 @@ func TestNil(t *testing.T) {
 }
 
 // TestClose tests if the close method returns any errors.
-//
-// Note: This test is only executed if the initial connection to Apache ZooKeeper works.
 func TestClose(t *testing.T) {
 	client := createClient(t, encoding.JSON)
 	err := client.Close()


### PR DESCRIPTION
In the past, probably before we had the `mage test all` that automatically spins up Docker containers for the different store implementation tests, it was useful to do connection tests and skip tests when no connection could be established, to not fail an entire test run, but instead allow to check in the output log for any _unexpected_ skips.

The Docker container start has been very reliable though, while OTOH I've been less often checking for skipped tests, and it's also cumbersome to check with the long test output (and not using `tparse` yet).

=> This PR removes the connection check and test skipping from almost all store implementation tests.

The exceptions:
- tablestorage and tablestore: Their test containers don't yet work correctly. So far they need to be tested locally, with actual credentials to the production cloud services. We should revisit their documentation, because since I last checked they might have improved/fixed their Docker images or improved their documentation on how to make them work.
- MySQL: For some reason the tests work fine locally (always) but _never_ work in CI. Haven't found out why yet. As an improvement over the previous state we replace the connection test with a check for the test environment and only skip the test in CI, but not locally.

We leave the `checkConnection` functions in the test files even if they're not called, because they're very handy as soon as connection issues pop up, to find out if it's from the `gokv` client specific code or the connection in general.