### PR TITLE
Fix missing gokv/sql update

### DIFF
--- a/sql/go.mod
+++ b/sql/go.mod
@@ -3,6 +3,6 @@ module github.com/philippgille/gokv/sql
 go 1.20
 
 require (
-	github.com/philippgille/gokv/encoding v0.6.0
+	github.com/philippgille/gokv/encoding v0.7.0
 	github.com/philippgille/gokv/util v0.7.0
 )

--- a/sql/go.sum
+++ b/sql/go.sum
@@ -1,4 +1,4 @@
-github.com/philippgille/gokv/encoding v0.6.0 h1:P1TN+Aulpd6Qd7qcLqgPwoxzOQ42UHBXOovWvFxJRI8=
-github.com/philippgille/gokv/encoding v0.6.0/go.mod h1:/yKvq2BKJlKJsH7KMDrhDlEw2Pt3V1nKyFhs4iOqz5U=
+github.com/philippgille/gokv/encoding v0.7.0 h1:2oxepKzzTsi00iLZBCZ7Rmqrallh9zws3iqSrLGfkgo=
+github.com/philippgille/gokv/encoding v0.7.0/go.mod h1:yncOBBUciyniPI8t5ECF8XSCwhONE9Rjf3My5IHs3fA=
 github.com/philippgille/gokv/util v0.7.0 h1:5avUK/a3aSj/aWjhHv4/FkqgMon2B7k2BqFgLcR+DYg=
 github.com/philippgille/gokv/util v0.7.0/go.mod h1:i9KLHbPxGiHLMhkix/CcDQhpPbCkJy5BkW+RKgwDHMo=


### PR DESCRIPTION
We previously only updated the gokv/test dependency, but not the gokv/encoding one.

For the process see https://github.com/philippgille/gokv/tree/v0.7.0/docs/releasing.md