### PR TITLE
Update Go and GitHub Actions for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.19', '1.20', '1.21' ]
+        go: [ '1.21', '1.22', '1.23', '1.24' ]
         os: [windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,3 +45,5 @@ jobs:
       #- run: build/combine-coverage.sh
       # Upload coverage data to codecov.io
       - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: 'false'
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
           cache-dependency-path: "**/go.sum"
@@ -34,7 +34,7 @@ jobs:
       # First build to check for compile errors
       - run: mage build
       # Then lint, taking `.golangci.yml` into account
-      - uses: golangci/golangci-lint-action@v3
+      - uses: golangci/golangci-lint-action@v8
       # Finally test all modules
       # This starts and stops Docker containers for services like PostgreSQL, Redis etc.
       # Takes up to 10m on GitHub Actions
@@ -44,4 +44,4 @@ jobs:
       # Combining of coverage reports not required with the action, which detects all reports in subdirectories and uploads all of them
       #- run: build/combine-coverage.sh
       # Upload coverage data to codecov.io
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v5

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,17 +1,33 @@
-# https://github.com/golangci/golangci-lint#config-file
-issues:
-  # Excluding configuration per-path and per-linter
-  exclude-rules:
-    # Ease some staticcheck warnings.
-    - path: (bigcache/bigcache_test\.go|bigcache\\bigcache_test\.go)
-      text: SA5001
-      linters:
-        - staticcheck
-    - path: (mysql/mysql_test\.go|mysql\\mysql_test\.go)
-      text: SA5001
-      linters:
-        - staticcheck
-    - path: (mysql/mysql\.go|mysql\\mysql\.go)
-      text: SA5001.*tempDB\.Close\(\)
-      linters:
-        - staticcheck
+version: "2"
+linters:
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - staticcheck
+        path: (bigcache/bigcache_test\.go|bigcache\\bigcache_test\.go)
+        text: SA5001
+      - linters:
+          - staticcheck
+        path: (mysql/mysql_test\.go|mysql\\mysql_test\.go)
+        text: SA5001
+      - linters:
+          - staticcheck
+        path: (mysql/mysql\.go|mysql\\mysql\.go)
+        text: SA5001.*tempDB\.Close\(\)
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+# https://golangci-lint.run/usage/configuration/#config-file
 version: "2"
 linters:
   exclusions:


### PR DESCRIPTION
- Updated Go versions to minimum 1.21 (for compatibility with new go directive version syntax, e.g. required [here](https://github.com/philippgille/gokv/pull/201)), and including all versions released since then
- Updated all GitHub Actions versions to their latest available version
- The latest Codecov Action version requires a token (if not disabling that requirement in the Codecov settings), so I've added it to the repo secrets and referencing it in the Action configuration