### PR TITLE
Update Apache Ignite test container health check

### DIFF
--- a/magefiles/test.go
+++ b/magefiles/test.go
@@ -73,7 +73,7 @@ func testImpl(impl string) (err error) {
 		dockerCmd += `hazelcast -p 5701:5701 --health-cmd='curl -f http://localhost:5701/hazelcast/health/node-state' --health-interval 1s ` + dockerImage
 	case "ignite":
 		dockerImage = "apacheignite/ignite"
-		dockerCmd += `ignite -p 10800:10800 --health-cmd='${IGNITE_HOME}/bin/control.sh --baseline | grep "Cluster state: active"' --health-interval 1s ` + dockerImage
+		dockerCmd += `ignite -p 10800:10800 --health-cmd='${IGNITE_HOME}/bin/control.sh --baseline | grep "Cluster state: ACTIVE"' --health-interval 1s ` + dockerImage
 	case "memcached":
 		dockerImage = "memcached"
 		dockerCmd += `memcached -p 11211:11211 --health-cmd='echo stats | nc -w 1 localhost 11211' --health-interval 1s ` + dockerImage


### PR DESCRIPTION
The gokv tests (`mage test all` / `mage test ignite`) lead to a timeout while waiting for the Ignite container to become healthy. This PR fixes that.

`grep` checks case-sensitive by default, and the cluster state is (now, potentially changed recently) `ACTIVE` and not `active`: https://github.com/apache/ignite/blob/2.17.0/docs/_docs/monitoring-metrics/cluster-states.adoc?plain=1#L35

---

Generally, pinning the Docker image version might've prevented the failure (as I think the tests worked in the past), but has the downside of not being certain whether gokv works with the latest database versions. Maybe best would be to run our test sets twice: Once with a pinned Docker image version, once with `latest`. I'll think about it.