### PR TITLE
Remove Go 1.21 and 1.22 from CI build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.21', '1.22', '1.23', '1.24' ]
+        go: [ '1.23', '1.24' ]
         os: [windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -82,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.21', '1.22', '1.23', '1.24' ]
+        go: [ '1.23', '1.24' ]
         os: [windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
We're reducing the size of the build matrix in CI, to speed up the GitHub Actions. We're now testing the latest 2 Go versions, same as what the Go team officially supports: https://go.dev/doc/devel/release#policy

We try to keep `gokv` compatible with older versions as well, we're just not testing it in CI anymore. If you run into issues with an older version please let us know, we can look into it and maybe adapt accordingly.